### PR TITLE
Walk the whole tree, thanks.

### DIFF
--- a/Microsoft.Maui.WebDriver.Host/MauiElement.cs
+++ b/Microsoft.Maui.WebDriver.Host/MauiElement.cs
@@ -27,6 +27,9 @@ namespace Microsoft.Maui.WebDriver.Host
 		{
 			get
 			{
+				if (NativeView is IContentView cv && cv.Content is not null)
+					return Enumerable.Repeat(new MauiElement(cv.Content), 1);
+
 				if (NativeView is ILayout layout)
 					return layout.Select(v => new MauiElement(v));
 

--- a/Microsoft.Maui.WebDriver.Host/PlatformDriverBase.cs
+++ b/Microsoft.Maui.WebDriver.Host/PlatformDriverBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Maui.WebDriver.Host
 		bool disposed;
 		void Dispose(bool disposing)
 		{
-			if (!disposing)
+			if (!disposed)
 			{
 				if (disposing)
 					DisposeManagedResources();


### PR DESCRIPTION
Some of the elements will implement `IContent` and not `ILayout` so we should walk those elements too.
Fixed a Dispose typo