### PR TITLE
Minor tweaks to get Android going

### DIFF
--- a/Microsoft.Maui.WebDriver.Host/AppBuilderExtensions.cs
+++ b/Microsoft.Maui.WebDriver.Host/AppBuilderExtensions.cs
@@ -4,34 +4,14 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Maui.Hosting;
-using Microsoft.Maui.LifecycleEvents;
 
 namespace Microsoft.Maui.WebDriver.Host
 {
 	public static class AppBuilderExtensions
 	{
 #if ANDROID
-		internal static Android.App.Activity CurrentActivity { get; set; }
+		internal static Android.App.Activity CurrentActivity => Microsoft.Maui.Essentials.Platform.CurrentActivity;
 #endif
-
-		public static MauiAppBuilder UseWebDriverHost(this MauiAppBuilder builder)
-		{
-			builder.ConfigureLifecycleEvents(l =>
-			{
-#if ANDROID
-				l.AddAndroid(android =>
-				{
-					android.AddEvent("OnResume", new AndroidLifecycle.OnResume(activity =>
-					{
-						CurrentActivity = activity;
-					}));
-				});
-#endif
-			});
-
-			return builder;
-		}
 
 		internal static void EnqueAll<T>(this Queue<T> q, IEnumerable<T> elems)
 		{

--- a/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidDriver.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidDriver.cs
@@ -6,6 +6,14 @@ namespace Microsoft.Maui.WebDriver.Host
 	// All the code in this file is only included on Android.
 	public class AndroidDriver : PlatformDriverBase
 	{
+		public AndroidDriver(Application app)
+			: base()
+		{
+			if (app == null)
+				throw new ArgumentNullException(nameof(app));
+			Microsoft.Maui.Essentials.Platform.Init(app);
+		}
+
 		public override IEnumerable<IPlatformElement> Views
 		{
 			get


### PR DESCRIPTION
I rerouted `CurrentActivity` into the essentials namespace.
This makes sense to me because we're not using `UseWebDriverHost` anywhere and `CurrentActivity` is only used in `AndroidDriver.cs` (note to self: should probably just move it there because that's where it's accessed - it isn't needed in the extensions).

This requires that the `AndroidDriver` class take an `Application` object, but since it's device-specific and it's only going to be run on Android, this seemed like a reasonable concession to me.

Otherwise, the code works as is.