### PR TITLE
Ios update

### DIFF
--- a/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSDriver.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSDriver.cs
@@ -10,10 +10,27 @@ namespace Microsoft.Maui.WebDriver.Host
 		{
 			get
 			{
-				var window = UIKit.UIApplication.SharedApplication.KeyWindow;
+				var window = KeyWindow;
+				if (window == null)
+					return Enumerable.Empty<IPlatformElement>();
 
 				return window.Subviews.Select(s => new iOSElement(s));
 			}
 		}
+
+		UIWindow KeyWindow
+        {
+			get
+            {
+				if (OperatingSystem.IsIOSVersionAtLeast (13))
+				{
+					return UIApplication.SharedApplication.Windows.FirstOrDefault(w => w.IsKeyWindow);
+				}
+				else
+                {
+					return UIKit.UIApplication.SharedApplication.KeyWindow;
+                }
+            }
+        }
 	}
 }

--- a/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSDriver.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSDriver.cs
@@ -19,18 +19,18 @@ namespace Microsoft.Maui.WebDriver.Host
 		}
 
 		UIWindow KeyWindow
-        {
+		{
 			get
-            {
-				if (OperatingSystem.IsIOSVersionAtLeast (13))
+			{
+				if (OperatingSystem.IsIOSVersionAtLeast(13))
 				{
 					return UIApplication.SharedApplication.Windows.FirstOrDefault(w => w.IsKeyWindow);
 				}
 				else
-                {
+				{
 					return UIKit.UIApplication.SharedApplication.KeyWindow;
-                }
-            }
-        }
+				}
+			}
+		}
 	}
 }

--- a/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSElement.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSElement.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Maui.WebDriver.Host
 
 		static string[] possibleTextPropertyNames = new string[]
 		{
-			"Title", "Text", 
+			"Title", "Text",
 		};
 
 		public string Text
@@ -45,16 +45,16 @@ namespace Microsoft.Maui.WebDriver.Host
 				{
 					IUITextInput ti => TextFromUIInput(ti),
 					UIButton b => b.CurrentTitle,
-					_ => TextViaReflection (NativeView, possibleTextPropertyNames)
-                };
+					_ => TextViaReflection(NativeView, possibleTextPropertyNames)
+				};
 
 			}
 		}
 
-		static string TextViaReflection (UIView view, string[] propertyNames)
-        {
+		static string TextViaReflection(UIView view, string[] propertyNames)
+		{
 			foreach (var name in propertyNames)
-            {
+			{
 				var prop = view.GetType().GetProperty("Text", typeof(string));
 				if (prop is null)
 					continue;
@@ -65,17 +65,17 @@ namespace Microsoft.Maui.WebDriver.Host
 				return prop.GetValue(view) as string ?? "";
 			}
 			return "";
-        }
+		}
 
-		static string TextFromUIInput (IUITextInput ti)
-        {
-            var start = ti.BeginningOfDocument;
-            var end = ti.EndOfDocument;
-            var range = ti.GetTextRange(start, end);
-            return ti.TextInRange(range);
-        }
+		static string TextFromUIInput(IUITextInput ti)
+		{
+			var start = ti.BeginningOfDocument;
+			var end = ti.EndOfDocument;
+			var range = ti.GetTextRange(start, end);
+			return ti.TextInRange(range);
+		}
 
-        public bool Selected =>
+		public bool Selected =>
 			NativeView.Focused;
 
 		public Point Location

--- a/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSElement.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/iOS/iOSElement.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Drawing;
 using System.Linq;
+using UIKit;
 
 namespace Microsoft.Maui.WebDriver.Host
 {
@@ -11,13 +12,15 @@ namespace Microsoft.Maui.WebDriver.Host
 	{
 		public iOSElement(UIKit.UIView nativeView)
 		{
+			if (nativeView == null)
+				throw new ArgumentNullException(nameof(nativeView));
 			NativeView = nativeView;
 		}
 
 		public UIKit.UIView NativeView { get; set; }
 
 		public string AutomationId
-			=> NativeView.AccessibilityIdentifier;
+			=> NativeView.AccessibilityIdentifier ?? "";
 
 		public bool Enabled
 			=> false;
@@ -28,23 +31,51 @@ namespace Microsoft.Maui.WebDriver.Host
 		public string TagName
 			=> NativeView.GetType().Name;
 
+		static string[] possibleTextPropertyNames = new string[]
+		{
+			"Title", "Text", 
+		};
+
 		public string Text
 		{
 			get
 			{
-				if (NativeView is UIKit.IUITextInput ti)
-				{
-					var start = ti.BeginningOfDocument;
-					var end = ti.EndOfDocument;
-					var range = ti.GetTextRange(start, end);
-					return ti.TextInRange(range);
-				}
 
-				return null;
+				return NativeView switch
+				{
+					IUITextInput ti => TextFromUIInput(ti),
+					UIButton b => b.CurrentTitle,
+					_ => TextViaReflection (NativeView, possibleTextPropertyNames)
+                };
+
 			}
 		}
 
-		public bool Selected =>
+		static string TextViaReflection (UIView view, string[] propertyNames)
+        {
+			foreach (var name in propertyNames)
+            {
+				var prop = view.GetType().GetProperty("Text", typeof(string));
+				if (prop is null)
+					continue;
+				if (!prop.CanRead)
+					continue;
+				if (prop.PropertyType != typeof(string))
+					continue;
+				return prop.GetValue(view) as string ?? "";
+			}
+			return "";
+        }
+
+		static string TextFromUIInput (IUITextInput ti)
+        {
+            var start = ti.BeginningOfDocument;
+            var end = ti.EndOfDocument;
+            var range = ti.GetTextRange(start, end);
+            return ti.TextInRange(range);
+        }
+
+        public bool Selected =>
 			NativeView.Focused;
 
 		public Point Location
@@ -108,7 +139,7 @@ namespace Microsoft.Maui.WebDriver.Host
 					return str.ToString();
 			}
 
-			return null;
+			return "";
 		}
 
 		public string GetCssValue(string propertyName)


### PR DESCRIPTION
Changes include:
- return `Enumerable.Empty<>` instead of null.
- use the correct APIs on the OS (drops warnings)
- added code for pulling out the `Text` field using reflection if needed.

Note that using reflection over a special case for a type takes about twice as long as reflection, so I have no problem adding to the switch statement for common view types.