### PR TITLE
make clicking work on android

### DIFF
--- a/Microsoft.Maui.WebDriver.Host/AppBuilderExtensions.cs
+++ b/Microsoft.Maui.WebDriver.Host/AppBuilderExtensions.cs
@@ -9,10 +9,6 @@ namespace Microsoft.Maui.WebDriver.Host
 {
 	public static class AppBuilderExtensions
 	{
-#if ANDROID
-		internal static Android.App.Activity CurrentActivity => Microsoft.Maui.Essentials.Platform.CurrentActivity;
-#endif
-
 		internal static void EnqueAll<T>(this Queue<T> q, IEnumerable<T> elems)
 		{
 			foreach (var elem in elems)

--- a/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidDriver.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidDriver.cs
@@ -1,30 +1,95 @@
 ﻿using System;
 using System.Collections.Generic;
+using Android.App;
+using Android.OS;
 
 namespace Microsoft.Maui.WebDriver.Host
 {
-	// All the code in this file is only included on Android.
-	public class AndroidDriver : PlatformDriverBase
-	{
-		public AndroidDriver(Application app)
-			: base()
-		{
-			if (app == null)
-				throw new ArgumentNullException(nameof(app));
-			Microsoft.Maui.Essentials.Platform.Init(app);
-		}
+    // All the code in this file is only included on Android.
+    public class AndroidDriver : PlatformDriverBase
+    {
+        public AndroidDriver(Application app)
+            : base()
+        {
+            if (app == null)
+                throw new ArgumentNullException(nameof(app));
+            Init(app);
+        }
 
-		public override IEnumerable<IPlatformElement> Views
-		{
-			get
-			{
-				var rootView = AppBuilderExtensions.CurrentActivity.Window?.DecorView?.RootView ??
-					AppBuilderExtensions.CurrentActivity.FindViewById(Android.Resource.Id.Content)?.RootView ??
-					AppBuilderExtensions.CurrentActivity.Window?.DecorView?.FindViewById(Android.Resource.Id.Content);
+        public override IEnumerable<IPlatformElement> Views
+        {
+            get
+            {
+                var rootView = CurrentActivity.Window?.DecorView?.RootView ??
+                    CurrentActivity.FindViewById(Android.Resource.Id.Content)?.RootView ??
+                    CurrentActivity.Window?.DecorView?.FindViewById(Android.Resource.Id.Content);
 
-				if (rootView is not null)
-					yield return new AndroidElement(rootView);
-			}
-		}
-	}
+                if (rootView is not null)
+                    yield return new AndroidElement(rootView);
+            }
+        }
+
+
+        // from Essentials:
+
+        static volatile Handler handler;
+
+        internal static void BeginInvokeOnMainThread(Action action)
+        {
+            if (handler?.Looper != Looper.MainLooper)
+                handler = new Handler(Looper.MainLooper);
+            handler!.Post(action);
+        }
+
+        internal static T InvokeOnMainThread<T>(Func<T> factory)
+        {
+            T value = default;
+            BeginInvokeOnMainThread(() => value = factory());
+            return value;
+        }
+
+        static ActivityLifecycleContextListener? lifecycleListener;
+
+        static void Init(Application application)
+        {
+            lifecycleListener = new ActivityLifecycleContextListener();
+            application.RegisterActivityLifecycleCallbacks(lifecycleListener);
+        }
+
+        static Activity CurrentActivity => lifecycleListener?.Activity;
+
+        class ActivityLifecycleContextListener : Java.Lang.Object, Application.IActivityLifecycleCallbacks
+        {
+            WeakReference<Activity> currentActivity = new WeakReference<Activity>(null);
+
+            internal Activity Activity
+            {
+                get => currentActivity.TryGetTarget(out var a) ? a : null;
+                set => currentActivity.SetTarget(value);
+            }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityCreated(Activity activity, Bundle savedInstanceState)
+            {
+                Activity = activity;
+            }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityDestroyed(Activity activity) { }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityPaused(Activity activity)
+            {
+                Activity = activity;
+            }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityResumed(Activity activity)
+            {
+                Activity = activity;
+            }
+
+            void Application.IActivityLifecycleCallbacks.OnActivitySaveInstanceState(Activity activity, Bundle outState) { }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityStarted(Activity activity) { }
+
+            void Application.IActivityLifecycleCallbacks.OnActivityStopped(Activity activity) { }
+        }
+    }
 }

--- a/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidElement.cs
+++ b/Microsoft.Maui.WebDriver.Host/Platforms/Android/AndroidElement.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Maui.WebDriver.Host
 
 		public void Click()
 		{
-			NativeView.CallOnClick();
+			AndroidDriver.InvokeOnMainThread(NativeView.PerformClick);
 		}
 
 		public string GetAttribute(string attributeName)


### PR DESCRIPTION
Android has similar problems with regards to thread safety.
The Android driver had an Essentials dependency which I removed. This changes better isolates all that code into AndrdoidDriver which is where it should have been in the first place.